### PR TITLE
Add license tag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ setup(
     version='0.2',
     description='A library to communicate with the Met Éireann Public Weather Forecast API',
     author='Dylan Gore',
+    license='MIT',
     url='https://github.com/DylanGore/PyMetEireann/',
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
Allow third-party tools (e. g., PyPI or `pyp2rpm`) to get the license details in a simple way.