### PR TITLE
Update API_URL, fixes home-assistant/core#131223

### DIFF
--- a/meteireann/__init__.py
+++ b/meteireann/__init__.py
@@ -9,7 +9,7 @@ import async_timeout
 import pytz
 import xmltodict
 
-API_URL = 'http://metwdb-openaccess.ichec.ie/metno-wdb2ts/locationforecast'
+API_URL = 'http://openaccess.pf.api.met.ie/metno-wdb2ts/locationforecast'
 WARNING_API_URL = 'https://www.met.ie/Open_Data/json/warning_'
 
 # Map each region code to a region name


### PR DESCRIPTION
The API URL has changed according to: https://data.gov.ie/dataset/fa9574c1-48f4-4a98-a22b-d1c23c433821/resource/5d156b15-38b8-4de9-921b-0ffc8704c88e